### PR TITLE
Add exponential backoff retries to SD WebUI client

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,31 +18,31 @@ class TestSDWebUIClient:
         assert client.base_url == "http://localhost:8080"
         assert client.timeout == 60
 
-    @patch("src.api.client.requests.get")
-    def test_check_api_ready_success(self, mock_get):
+    @patch("src.api.client.requests.request")
+    def test_check_api_ready_success(self, mock_request):
         """Test successful API readiness check"""
         mock_response = Mock()
-        mock_response.status_code = 200
-        mock_get.return_value = mock_response
+        mock_response.raise_for_status.return_value = None
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
         assert client.check_api_ready(max_retries=1) is True
 
-    @patch("src.api.client.requests.get")
-    def test_check_api_ready_failure(self, mock_get):
+    @patch("src.api.client.requests.request")
+    def test_check_api_ready_failure(self, mock_request):
         """Test failed API readiness check"""
-        mock_get.side_effect = Exception("Connection error")
+        mock_request.side_effect = Exception("Connection error")
 
         client = SDWebUIClient()
         assert client.check_api_ready(max_retries=1, retry_delay=0) is False
 
-    @patch("src.api.client.requests.post")
-    def test_txt2img_success(self, mock_post):
+    @patch("src.api.client.requests.request")
+    def test_txt2img_success(self, mock_request):
         """Test successful txt2img request"""
         mock_response = Mock()
-        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"images": ["base64data"]}
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
         result = client.txt2img({"prompt": "test"})
@@ -51,23 +51,23 @@ class TestSDWebUIClient:
         assert "images" in result
         assert len(result["images"]) == 1
 
-    @patch("src.api.client.requests.post")
-    def test_txt2img_failure(self, mock_post):
+    @patch("src.api.client.requests.request")
+    def test_txt2img_failure(self, mock_request):
         """Test failed txt2img request"""
-        mock_post.side_effect = Exception("API error")
+        mock_request.side_effect = Exception("API error")
 
         client = SDWebUIClient()
         result = client.txt2img({"prompt": "test"})
 
         assert result is None
 
-    @patch("src.api.client.requests.post")
-    def test_img2img_success(self, mock_post):
+    @patch("src.api.client.requests.request")
+    def test_img2img_success(self, mock_request):
         """Test successful img2img request"""
         mock_response = Mock()
-        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"images": ["base64data"]}
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
         result = client.img2img({"prompt": "test", "init_images": ["img"]})
@@ -75,27 +75,27 @@ class TestSDWebUIClient:
         assert result is not None
         assert "images" in result
 
-    @patch("src.api.client.requests.post")
-    def test_upscale_success(self, mock_post):
+    @patch("src.api.client.requests.request")
+    def test_upscale_success(self, mock_request):
         """Test successful upscale request"""
         mock_response = Mock()
-        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"image": "base64data"}
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
-        result = client.upscale("base64image")
+        result = client.upscale({"image": "base64image"})
 
         assert result is not None
         assert "image" in result
 
-    @patch("src.api.client.requests.get")
-    def test_get_models(self, mock_get):
+    @patch("src.api.client.requests.request")
+    def test_get_models(self, mock_request):
         """Test get models request"""
         mock_response = Mock()
-        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = [{"name": "model1"}]
-        mock_get.return_value = mock_response
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
         result = client.get_models()
@@ -103,13 +103,13 @@ class TestSDWebUIClient:
         assert len(result) == 1
         assert result[0]["name"] == "model1"
 
-    @patch("src.api.client.requests.get")
-    def test_get_samplers(self, mock_get):
+    @patch("src.api.client.requests.request")
+    def test_get_samplers(self, mock_request):
         """Test get samplers request"""
         mock_response = Mock()
-        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = [{"name": "Euler a"}]
-        mock_get.return_value = mock_response
+        mock_request.return_value = mock_response
 
         client = SDWebUIClient()
         result = client.get_samplers()

--- a/tests/test_api_client_backoff.py
+++ b/tests/test_api_client_backoff.py
@@ -1,0 +1,68 @@
+"""Tests for SDWebUIClient retry backoff behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from src.api.client import SDWebUIClient
+
+
+@pytest.fixture()
+def client():
+    """Create an SDWebUIClient with deterministic backoff."""
+    return SDWebUIClient(max_retries=4, backoff_factor=1.0, jitter=0.0)
+
+
+def test_retry_backoff_sequence(monkeypatch, client):
+    """The client should apply exponential backoff between retry attempts."""
+
+    attempt_counter = {"count": 0}
+    sleep_calls: list[float] = []
+
+    def fake_request(method, url, timeout=None, **kwargs):  # noqa: ANN001
+        attempt_counter["count"] += 1
+        if attempt_counter["count"] < 4:
+            raise requests.exceptions.ConnectionError("boom")
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"ok": True}
+        return response
+
+    def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr("src.api.client.requests.request", fake_request)
+    monkeypatch.setattr(client, "_sleep", fake_sleep)
+
+    response = client._perform_request("get", "/retry", timeout=1)
+
+    assert response is not None
+    assert attempt_counter["count"] == 4
+    assert sleep_calls == [1.0, 2.0, 4.0]
+
+
+def test_retry_terminates_after_max_attempts(monkeypatch):
+    """The client should stop retrying after the configured attempts."""
+
+    client = SDWebUIClient(max_retries=3, backoff_factor=1.0, jitter=0.0)
+    attempt_counter = {"count": 0}
+    sleep_calls: list[float] = []
+
+    def fake_request(method, url, timeout=None, **kwargs):  # noqa: ANN001
+        attempt_counter["count"] += 1
+        raise requests.exceptions.HTTPError("nope")
+
+    def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr("src.api.client.requests.request", fake_request)
+    monkeypatch.setattr(client, "_sleep", fake_sleep)
+
+    response = client._perform_request("post", "/retry", timeout=1)
+
+    assert response is None
+    assert attempt_counter["count"] == 3
+    assert sleep_calls == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- add configurable exponential backoff with jitter to the SDWebUIClient and centralize request handling
- update all client endpoints to reuse the retry helper and expose configuration knobs
- cover the retry flow with new tests and adjust existing API client tests to mock the new request entry point

## Testing
- pytest -k backoff -q
- pytest tests/test_api.py -q
- pytest tests/test_api_client.py -q
- pytest -q *(fails: Tkinter display unavailable in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_690ad71032ac8330a01e986b53942735