### PR TITLE
Fix sampler scheduler parsing for txt2img

### DIFF
--- a/src/pipeline/executor.py
+++ b/src/pipeline/executor.py
@@ -182,8 +182,8 @@ class Pipeline:
             "prompt": prompt,
             "negative_prompt": enhanced_negative,
             "steps": config.get("steps", 20),
-            "sampler_name": config.get("sampler_name", "Euler a"),
-            "scheduler": config.get("scheduler", "Normal"),
+            "sampler_name": sampler_config["sampler_name"],
+            "scheduler": sampler_config.get("scheduler", "Automatic"),
             "cfg_scale": config.get("cfg_scale", 7.0),
             "width": config.get("width", 512),
             "height": config.get("height", 512),
@@ -958,6 +958,9 @@ class Pipeline:
             if txt2img_config.get("vae"):
                 self.client.set_vae(txt2img_config["vae"])
 
+            # Parse sampler configuration for this stage
+            sampler_config = self._parse_sampler_config(txt2img_config)
+
             # Log configuration validation
             logger.debug(f"📝 Input txt2img config: {json.dumps(txt2img_config, indent=2)}")
 
@@ -965,8 +968,8 @@ class Pipeline:
                 "prompt": prompt,
                 "negative_prompt": enhanced_negative,
                 "steps": txt2img_config.get("steps", 20),
-                "sampler_name": txt2img_config.get("sampler_name", "Euler a"),
-                "scheduler": txt2img_config.get("scheduler", "normal"),
+                "sampler_name": sampler_config["sampler_name"],
+                "scheduler": sampler_config.get("scheduler", "Automatic"),
                 "cfg_scale": txt2img_config.get("cfg_scale", 7.0),
                 "width": txt2img_config.get("width", 512),
                 "height": txt2img_config.get("height", 512),

--- a/tests/test_txt2img_stage.py
+++ b/tests/test_txt2img_stage.py
@@ -40,3 +40,39 @@ def test_run_txt2img_stage_basic(pipeline, tmp_path):
     assert result["name"] == image_name
     assert result["stage"] == "txt2img"
     assert "path" in result
+
+
+def test_run_txt2img_applies_scheduler_from_sampler(pipeline, tmp_path):
+    prompt = "city skyline"
+    config = {"sampler_name": "DPM++ 2M Karras"}
+
+    with patch("src.pipeline.executor.save_image_from_base64", return_value=True):
+        pipeline.run_txt2img(prompt, config, tmp_path, batch_size=1)
+
+    assert pipeline.client.txt2img.called
+    payload = pipeline.client.txt2img.call_args[0][0]
+    assert payload["sampler_name"] == "DPM++ 2M"
+    assert payload["scheduler"] == "Karras"
+
+
+def test_run_txt2img_stage_applies_scheduler_from_sampler(pipeline, tmp_path):
+    prompt = "lakeside cabin"
+    negative_prompt = "lowres"
+    config = {"txt2img": {"sampler_name": "DPM++ 2M Karras"}}
+    image_name = "cabin_test"
+    output_dir = tmp_path / "txt2img_stage"
+    output_dir.mkdir(exist_ok=True)
+
+    with patch("src.pipeline.executor.save_image_from_base64", return_value=True):
+        pipeline.run_txt2img_stage(
+            prompt,
+            negative_prompt,
+            config,
+            output_dir,
+            image_name,
+        )
+
+    assert pipeline.client.txt2img.called
+    payload = pipeline.client.txt2img.call_args[0][0]
+    assert payload["sampler_name"] == "DPM++ 2M"
+    assert payload["scheduler"] == "Karras"


### PR DESCRIPTION
## Summary
- update txt2img payload creation to reuse `_parse_sampler_config` so legacy sampler strings pick the right scheduler
- apply the same sampler parsing in `run_txt2img_stage` for GUI pack runs
- add regression tests covering legacy sampler strings and their derived scheduler values

## Testing
- `pytest tests/test_txt2img_stage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_690b40afaa04833083eab8e47a0af2d1