### PR TITLE
Add headless test for pipeline progress and ETA callbacks

### DIFF
--- a/tests/gui/test_progress_eta.py
+++ b/tests/gui/test_progress_eta.py
@@ -70,7 +70,7 @@ def test_progress_eta_display(monkeypatch):
         status_var = getattr(win, "progress_status_var", None)
         eta_var = getattr(win, "progress_eta_var", None)
 
-        assert progress_bar is not None, "MainWindow should expose progress_bar"  # pragma: no cover - clarity
+        assert progress_bar is not None, "MainWindow should expose progress_bar"
         assert status_var is not None, "MainWindow should expose progress_status_var"
         assert eta_var is not None, "MainWindow should expose progress_eta_var"
 


### PR DESCRIPTION
## Summary
- add a headless-safe GUI regression test for the progress/ETA widgets
- stub the pipeline controller so the test can directly drive progress, ETA, and cancel callbacks

## Testing
- not run (Tk callbacks not yet implemented in GUI)

------
https://chatgpt.com/codex/tasks/task_e_690b425fd4dc8330a07cbe85e813ce76