### PR TITLE
Document demo asset workflow without binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,41 @@ Everything is designed to be **reproducible, inspectable, and testable** — no 
 
 ---
 
-### Core Intent
+## Table of Contents
+
+- [Overview](#overview)
+- [Core Intent](#core-intent)
+- [Features](#features)
+  - [Core Pipeline](#core-pipeline)
+  - [User Interface](#user-interface)
+  - [Enhanced Configuration Features](#enhanced-configuration-features)
+  - [Technical Features](#technical-features)
+  - [Content Creation](#content-creation)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Desktop Launcher (Recommended)](#desktop-launcher-recommended)
+  - [GUI Mode](#gui-mode)
+  - [Pipeline Control](#pipeline-control)
+  - [CLI Mode](#cli-mode)
+  - [Demo Assets](#demo-assets)
+- [Project Structure](#project-structure)
+- [Documentation](#documentation)
+- [External File dependencies](#external-file-dependencies)
+- [Example Prompt Pack format](#example-prompt-pack-format)
+- [Recommended Prompt Pack Format](#recommended-prompt-pack-format)
+- [Testing](#testing)
+- [License](#license)
+- [Technical Highlights](#technical-highlights)
+- [Why It Exists](#why-it-exists)
+- [Future Extensions](#future-extensions)
+- [Developer Notes](#developer-notes)
+- [Example One-Click Flow](#example-one-click-flow)
+- [Mission Statement](#mission-statement)
+
+---
+
+## Core Intent
 
 To build a modular, testable system that transforms written prompts into cinematic video clips using Stable Diffusion, with full transparency of inputs, parameters, and outputs.
 
@@ -32,9 +66,6 @@ The architecture emphasizes:
 ## Features
 
 ### Core Pipeline
-```
-
-### Core Pipeline
 
 - **Automated Workflow**: txt2img → img2img cleanup → upscale → video creation
 - **Flexible Stage Control**: Skip img2img or upscale stages as needed via configuration
@@ -42,9 +73,9 @@ The architecture emphasizes:
 - **Advanced Integrations**: Embeddings, LORAs, and custom model support
 - **Global NSFW Prevention**: Automatic negative prompt enhancement for all generations
 
-**Pipeline Configuration:**
+**Pipeline Configuration**
 
-You can control which pipeline stages run by setting flags in your configuration:
+Control pipeline stages by setting flags in your configuration:
 
 ```json
 {
@@ -55,7 +86,7 @@ You can control which pipeline stages run by setting flags in your configuration
 }
 ```
 
-**Stage Combinations:**
+**Stage Combinations**
 - `txt2img → img2img → upscale` (all stages, default)
 - `txt2img → upscale` (skip img2img for faster results)
 - `txt2img → img2img` (skip upscale to save time)
@@ -180,6 +211,18 @@ The GUI provides full control over pipeline execution with responsive feedback:
 ```bash
 python -m src.cli --prompt "your prompt here" --preset default
 ```
+
+### Demo Assets
+
+Reusable walkthroughs for the GUI are cataloged in [`docs/assets/core_flows/`](docs/assets/core_flows/README.md). The actual compressed media lives on the team’s shared asset drive (`/docs/media/core_flows/` on SharePoint) so that binaries stay out of the repository.
+
+To embed the demos in documentation or release notes:
+
+1. Download the required asset (for example, `txt2img_pipeline.webp`) from the shared drive.
+2. Copy it alongside the published documentation (documentation portal, release bundle, etc.).
+3. Reference it in Markdown with a relative link such as `![Pipeline walkthrough](docs/assets/core_flows/txt2img_pipeline.webp)`.
+
+Keep each capture under 2 MB and prefer `.webp`/`.gif` formats for high-quality, low-size walkthroughs.
 
 ## Project Structure
 

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,9 @@
+# Demo Asset Storage
+
+Binary walkthroughs are **not** committed to the repository. Instead, this folder documents which assets exist and how to retrieve them from the shared media drive.
+
+- Maintain per-feature indexes (for example, `core_flows/README.md`) that describe the latest filenames and destinations.
+- Store the actual `.webp`/`.gif` captures on the `/docs/media/` SharePoint library, keeping each file under 2 MB.
+- When updating an asset, refresh the index so downstream docs always point to the correct filename.
+
+Before publishing documentation, download the assets from SharePoint and bundle them with the site or release package rather than checking them into git.

--- a/docs/assets/core_flows/README.md
+++ b/docs/assets/core_flows/README.md
@@ -1,0 +1,19 @@
+# Core Flow Media Index
+
+No binary assets are checked into the repository. This index documents the canonical media that illustrate StableNew's GUI flows and where to fetch them when preparing release materials.
+
+## Available Walkthroughs
+
+| Flow | Filename | Description | Storage Location |
+|------|----------|-------------|------------------|
+| End-to-end pipeline overview | `txt2img_pipeline.webp` | Demonstrates txt2img → img2img → upscale orchestration with status updates. | Publish to shared asset drive (`/docs/media/core_flows/` on the team SharePoint) |
+| Prompt pack management highlights | `prompt_pack_management.webp` | Shows pack selection, validation, and override workflow. | Publish to shared asset drive (`/docs/media/core_flows/` on the team SharePoint) |
+
+Download the assets from the storage location above before embedding them in documentation or release notes. Compress new captures to <2 MB each, prefer `.webp`/`.gif`, and update this index if filenames change.
+
+## Usage Guidance
+
+- Embed walkthroughs in Markdown using relative links (for example, `![Prompt packs](docs/assets/core_flows/prompt_pack_management.webp)`), but ensure the binary itself is delivered out-of-band (for example, via release bundle or CDN).
+- When publishing documentation, copy the referenced assets into the documentation site or release package; do **not** commit them to the repository.
+- Keep filenames stable to avoid broken references in downstream portals.
+


### PR DESCRIPTION
## Summary
- document in the README how to reference GUI walkthrough assets while keeping binaries outside the repo
- update docs/assets guidance to track media indexes that point to the shared asset drive
- replace committed walkthrough binaries with a text index describing available captures and their storage locations

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690ad71e24d08330b293801c2a183778